### PR TITLE
Rewrite for WebPack loader API v2, updating dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,15 @@
 var loaderUtils = require('loader-utils');
 var MessageFormat = require('messageformat');
 
-module.exports = function(content) {
-  var query = loaderUtils.parseQuery(this.query);
-  var locale = query.locale || 'en';
-  var messages = (Array.isArray(this.inputValue) && typeof this.inputValue[0] === 'object') ? this.inputValue[0] : this.exec(content, this.resource);
-  var messageFormat = new MessageFormat(locale);
-  if (query.disablePluralKeyChecks) {
-    messageFormat.disablePluralKeyChecks();
-  }
-  if (query.intlSupport) {
-    messageFormat.setIntlSupport(true);
-  }
-  var messageFunctions = messageFormat.compile(messages);
-
-  this.cacheable && this.cacheable();
-  this.value = [ messageFunctions ];
-
-  return messageFunctions.toString('module.exports');
-};
+module.exports = function(messages) {
+  var options = loaderUtils.getOptions(this);
+  let lc = options.locale;
+  if (typeof lc === 'string' && lc.indexOf(',') !== -1) lc = lc.split(',');
+  var mf = new MessageFormat(lc);
+  if (options.biDiSupport) mf.setBiDiSupport();
+  if (options.disablePluralKeyChecks) mf.disablePluralKeyChecks();
+  if (options.formatters) mf.addFormatters(options.formatters);
+  if (options.intlSupport) mf.setIntlSupport(true);
+  if (options.strictNumberSign) mf.setStrictNumberSign();
+  return mf.compile(JSON.parse(messages)).toString('module.exports');
+}

--- a/index.js
+++ b/index.js
@@ -1,15 +1,31 @@
 var loaderUtils = require('loader-utils');
 var MessageFormat = require('messageformat');
 
-module.exports = function(messages) {
+module.exports = function(content) {
   var options = loaderUtils.getOptions(this);
-  let lc = options.locale;
-  if (typeof lc === 'string' && lc.indexOf(',') !== -1) lc = lc.split(',');
-  var mf = new MessageFormat(lc);
-  if (options.biDiSupport) mf.setBiDiSupport();
-  if (options.disablePluralKeyChecks) mf.disablePluralKeyChecks();
-  if (options.formatters) mf.addFormatters(options.formatters);
-  if (options.intlSupport) mf.setIntlSupport(true);
-  if (options.strictNumberSign) mf.setStrictNumberSign();
-  return mf.compile(JSON.parse(messages)).toString('module.exports');
-}
+  var locale = options.locale;
+  if (typeof locale === 'string' && locale.indexOf(',') !== -1) locale = locale.split(',');
+  var messages = JSON.parse(content);
+  var messageFormat = new MessageFormat(locale);
+  if (options.disablePluralKeyChecks) {
+    messageFormat.disablePluralKeyChecks();
+  }
+  if (options.intlSupport) {
+    messageFormat.setIntlSupport(true);
+  }
+  if (options.biDiSupport) {
+    messageFormat.setBiDiSupport();
+  }
+  if (options.formatters) {
+    messageFormat.addFormatters(options.formatters);
+  }
+  if (options.strictNumberSign) {
+    messageFormat.setStrictNumberSign();
+  }
+  var messageFunctions = messageFormat.compile(messages);
+
+  this.cacheable && this.cacheable();
+  this.value = [ messageFunctions ];
+
+  return messageFunctions.toString('module.exports');
+};

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   },
   "homepage": "https://github.com/cletusw/messageformat-loader#readme",
   "peerDependencies": {
-    "messageformat": "^1.0.0-rc.3"
+    "messageformat": "1.x"
   },
   "dependencies": {
-    "loader-utils": "^0.2.15"
+    "loader-utils": "^1.1.0"
   }
 }


### PR DESCRIPTION
The WebPack loader API has changed a bit from the [version](https://webpack.github.io/docs/loaders.html) used by WebPack 1 to [that](https://webpack.js.org/api/loaders/) used by WebPack 2 & 3.

As I couldn't get messageformat-loader to work with the latest WebPack, I ended up effectively rewriting it. Its internals are rather different, but the API is pretty much the same as the current one, just extended for the rest of the messageformat.js options, and it should work in all WebPack versions.

I have no intentions here of stepping on anyone's toes, I just needed a loader that worked for me. @cletusw, if this PR is acceptable to you, would you be interested in having this repo be transferred under the official `messageformat` GitHub org and e.g. renamed to `messageformat/loader`? Keeping you as the primary owner, of course.