### PR TITLE
Update config for WebPack 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For a working demo of the loader, run `npm install` in the `example/` directory,
 {
   test: /\bmessages\.json$/,
   loader: require.resolve('messageformat-loader'),
+  type: "javascript/auto", // Required for WebPack 4
   options: {
     biDiSupport: false,
     disablePluralKeyChecks: false,


### PR DESCRIPTION
WebPack 4 requires that you specify `{ type: "javascript/auto" }` in the loader config. If you don't, the output of messageformat-loader will be passed to the default JSON loader, which will fail because the content is no longer JSON.

I'm actually not sure if it's possible to do this inside of the `require` statement.