### PR TITLE
fix(loader): allow use without options

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var loaderUtils = require('loader-utils');
 var MessageFormat = require('messageformat');
 
 module.exports = function(content) {
-  var options = loaderUtils.getOptions(this);
+  var options = loaderUtils.getOptions(this) || {};
   var locale = options.locale;
   if (typeof locale === 'string' && locale.indexOf(',') !== -1) locale = locale.split(',');
   var messages = JSON.parse(content);


### PR DESCRIPTION
When using the loader without options the getOptions function will return null: https://github.com/webpack/loader-utils#getoptions
As an example, my webpack config for the loader just looks like `{test: /\.lang\.json$/, loader: 'messageformat-loader'}` which
causes this error to be thrown:
`TypeError: Cannot read property 'locale' of null`